### PR TITLE
The code works, but if the server is already a DC it fails. changing …

### DIFF
--- a/library/domain_controller.ps1
+++ b/library/domain_controller.ps1
@@ -5,9 +5,9 @@
 
 $params = Parse-Args $args;
 
-$result = New-Object PSObject -Property @{
+$result = New-Object psobject @{
     changed = $false
-}
+};
 
 If ($params.domain_name) {
     $domainName = $params.domain_name


### PR DESCRIPTION
Dear Ian,

Thanks for the GREAT work! I’ve found that it return an error if the server is already a DC.

replacing the following lines

$result = New-Object PSObject -Property @{
changed = $false
}

with those:

$result = New-Object psobject @{
    changed = $false
};

did the trick ;-)

Mohamed Ghaleb
